### PR TITLE
fix: Add missing 'rembg' dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,6 @@ safetensors
 scikit-image
 pybind11
 timm
+rembg
 
 meshlib


### PR DESCRIPTION

#### What does this PR do?
This pull request adds the `rembg` package to the `requirements.txt` file.

#### Why is this change necessary?
On a fresh installation of this custom node, ComfyUI fails to load it and throws a `ModuleNotFoundError: No module named 'rembg'` in the console.

The `rembg` library is a direct dependency for the background removal functionality but was not declared in the project's requirements. This change ensures that users can automatically install all necessary dependencies via `pip`, preventing the node from failing to load.

#### How have you tested this?
1.  Set up a clean ComfyUI virtual environment.
2.  Cloned the repository and tried to start ComfyUI.
3.  **Result (Before):** Confirmed the `ModuleNotFoundError` appeared and the nodes were not loaded.
4.  Applied this change (added `rembg` to `requirements.txt`).
5.  Ran `pip install -r requirements.txt` from within the node's directory.
6.  **Result (After):** Restarted ComfyUI, the error was gone, and the nodes loaded successfully.

This resolves the installation issue for new users.
