### PR TITLE
Fix NameError: 'dir_name' not defined in Hy3DHighPolyToLowPolyBakeMul…

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1910,7 +1910,7 @@ class Hy3DHighPolyToLowPolyBakeMultiViewsWithMetaData:
                         albedos.append(albedo)
                         
                     for file in loaded_metaData.mrs:
-                        mr_file = os.path.join(dir_name,file)
+                        mr_file = os.path.join(input_dir,file)
                         mr = Image.open(mr_file)
                         mrs.append(mr)
 


### PR DESCRIPTION
…tiViewsWithMetaData

In the `process` method of `Hy3DHighPolyToLowPolyBakeMultiViewsWithMetaData`,  the variable `dir_name` is used in the non-upscaled MR loop but is never defined  in that scope. It should be `input_dir`, which is defined earlier in the same method.

Line ~1913:
- mr_file = os.path.join(dir_name, file)
+ mr_file = os.path.join(input_dir, file)