### PR TITLE
Fix Linux config imports and Paint PBR loading

### DIFF
--- a/hy3dpaint/utils/multiview_utils.py
+++ b/hy3dpaint/utils/multiview_utils.py
@@ -45,7 +45,8 @@ class multiviewDiffusionNet:
         pipeline = HunyuanPaintPipeline.from_pretrained(
             model_path,
             torch_dtype=torch.float16,
-            use_fast=False
+            use_fast=False,
+            trust_remote_code=True
         )
 
         pipeline.scheduler = EulerAncestralDiscreteScheduler.from_config(pipeline.scheduler.config, timestep_spacing="trailing")

--- a/hy3dshape/hy3dshape/pipelines.py
+++ b/hy3dshape/hy3dshape/pipelines.py
@@ -113,15 +113,23 @@ def export_to_trimesh(mesh_output):
 
 
 def get_obj_from_str(string, reload=False):
-    module, cls = string.rsplit(".", 1)
+    # Config targets begin with a dot, but the ComfyUI custom-node folder
+    # contains hyphens and therefore cannot be used as a Python package name.
+    # Import from the custom-node root using an absolute module path instead.
+    import sys
+    from pathlib import Path
+
+    plugin_root = str(Path(__file__).resolve().parents[2])
+    if plugin_root not in sys.path:
+        sys.path.insert(0, plugin_root)
+
+    module, cls = string.lstrip(".").rsplit(".", 1)
+    module_imp = importlib.import_module(module)
+
     if reload:
-        module_imp = importlib.import_module(module)
-        importlib.reload(module_imp)
-    try:
-        obj = getattr(importlib.import_module(module, package=os.path.basename(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))), cls)
-    except:
-        obj = getattr(importlib.import_module(module, package=os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath( __file__ ))))), cls)
-    return obj
+        module_imp = importlib.reload(module_imp)
+
+    return getattr(module_imp, cls)
 
 
 def instantiate_from_config(config, **kwargs):


### PR DESCRIPTION
## Summary

This fixes two issues encountered while running the Hunyuan3D 2.1 workflow on Linux with ComfyUI:

- Resolve configured model classes independently of the ComfyUI installation path and the hyphenated custom-node directory name.
- Allow loading the custom Diffusers code included with the official `tencent/Hunyuan3D-2.1` Paint PBR model.

## Config import fix

The configured model targets use a leading dot, while the custom-node directory contains hyphens and therefore cannot be imported as a regular Python package name. The previous fallback could also interpret parts of a filesystem path, such as `.comfyui`, as Python modules.

The new implementation:

- Adds the actual plugin root to `sys.path`.
- Removes the leading relative-import marker from the configured target.
- Imports the target through its absolute module path.
- Reloads the imported module only when requested.

This addresses the behavior reported in issue #8 without requiring users to rename or move their ComfyUI installation.

## Paint pipeline fix

The official Paint PBR snapshot contains custom Diffusers modules. Recent Diffusers versions require `trust_remote_code=True` before loading those modules.

The model repository used by this node is fixed to the official `tencent/Hunyuan3D-2.1` repository.

## Testing

Tested successfully with:

- CachyOS / Arch Linux
- AMD Radeon RX 7900 XTX (`gfx1100`)
- ROCm 7.2
- Python 3.12.13
- PyTorch 2.9.1 + ROCm 7.2
- ComfyUI 0.29.0
- SDPA attention

Validated:

- Python compilation of both modified files
- Dynamic import of `HunYuanDiTPlain`
- Shape diffusion and FlashVDM mesh decoding
- Paint PBR pipeline loading
- DINOv2 loading
- Multi-view generation and texture baking
- Successful PBR GLB export

## Validation command

```bash
python -m py_compile hy3dshape/hy3dshape/pipelines.py hy3dpaint/utils/multiview_utils.py
```
